### PR TITLE
[-] MO: Solved critical error on product-comparison

### DIFF
--- a/socialsharing.php
+++ b/socialsharing.php
@@ -158,6 +158,9 @@ class SocialSharing extends Module
 		$this->context->controller->addCss($this->_path.'css/socialsharing.css');
 		$this->context->controller->addJS($this->_path.'js/socialsharing.js');
 
+		if (!isset($this->context->controller->php_self) || !in_array($this->context->controller->php_self, array('product')))
+			return;
+
 		$product = $this->context->controller->getProduct();
 
 		if (!Validate::isLoadedObject($product)) {


### PR DESCRIPTION
You cannot access `$this->context->controller->getProduct()` from product-comparison page:

`Fatal error: Call to undefined method CompareController::getProduct()`

With this change we make sure that code for product page is loaded only if controller == product